### PR TITLE
Make downloads easier to understand

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -240,58 +240,51 @@
 	Vibrant Shaders (Latest update: January 1, 2022):<br>
 	<table class="downloads">
 	<tr>
+		<td></td>
+		<td>Public downloads</td>
+		<td>Patreon Early Access</td>
+	</tr>
+	<tr>
 		<td>Sildur's Vibrant shaders v1.32 Lite</td>
 		<td><a href="//adfoc.us/39232281938028" target="_blank"
 			rel="noopener">v1.31(old)</a></td>
-		<td><a href="" target="_blank"
+		<td><a href="//www.patreon.com/Sildur" target="_blank"
 			rel="noopener">v1.32 (January 1st)</a></td>
-		<td><a href="//www.patreon.com/Sildur"
-		target="_blank" rel="noopener">Patreon Early Access</a></td>
 	</tr>
 	<tr>
 		<td>Sildur's Vibrant shaders v1.32 Medium</td>
 		<td><a href="//adfoc.us/39232281938039" target="_blank"
 			rel="noopener">v1.31(old)</a></td>
-		<td><a href="" target="_blank"
+		<td><a href="//www.patreon.com/Sildur" target="_blank"
 			rel="noopener">v1.32 (January 1st)</a></td>
-		<td><a href="//www.patreon.com/Sildur"
-		target="_blank" rel="noopener">Patreon Early Access</a></td>
 	</tr>
 	<tr>
 		<td>Sildur's Vibrant shaders v1.32 High</td>
 		<td><a href="//adfoc.us/39232281938045" target="_blank"
 			rel="noopener">v1.31(old)</a></td>
-		<td><a href="" target="_blank"
+		<td><a href="//www.patreon.com/Sildur" target="_blank"
 			rel="noopener">v1.32 (January 1st)</a></td>
-		<td><a href="//www.patreon.com/Sildur"
-		target="_blank" rel="noopener">Patreon Early Access</a></td>
 	</tr>
 	<tr>
 		<td>Sildur's Vibrant shaders v1.32 High-Motionblur</td>
 		<td><a href="//adfoc.us/39232281938053" target="_blank"
 			rel="noopener">v1.31(old)</a></td>
-		<td><a href="" target="_blank"
+		<td><a href="//www.patreon.com/Sildur" target="_blank"
 			rel="noopener">v1.32 (January 1st)</a></td>
-		<td><a href="//www.patreon.com/Sildur"
-		target="_blank" rel="noopener">Patreon Early Access</a></td>
 	</tr>
 	<tr>
 		<td>Sildur's Vibrant shaders v1.32 Extreme</td>
 		<td><a href="//adfoc.us/39232281938082" target="_blank"
 			rel="noopener">v1.31(old)</a></td>
-		<td><a href="" target="_blank"
+		<td><a href="//www.patreon.com/Sildur" target="_blank"
 			rel="noopener">v1.32 (January 1st)</a></td>
-		<td><a href="//www.patreon.com/Sildur"
-		target="_blank" rel="noopener">Patreon Early Access</a></td>
 	</tr>
 	<tr>
 		<td>Sildur's Vibrant shaders v1.32 Extreme-Volumetric lighting</td>
 		<td><a href="//adfoc.us/39232281938067" target="_blank"
 			rel="noopener">v1.31(old)</a></td>
-		<td><a href="" target="_blank"
+		<td><a href="//www.patreon.com/Sildur" target="_blank"
 			rel="noopener">v1.32 (January 1st)</a></td>
-		<td><a href="//www.patreon.com/Sildur"
-		target="_blank" rel="noopener">Patreon Early Access</a></td>
 	</tr>
 	<tr>
 		<td><a href="/changelogs/#vibrant" rel="section">Changelog</a></td>
@@ -304,22 +297,23 @@
 	Enhanced Default (Latest update: January 1, 2022):<br>
 	<table class="downloads">
 	<tr>
+		<td></td>
+		<td>Public downloads</td>
+		<td>Patreon Early Access</td>
+	</tr>
+	<tr>
 		<td>Sildur's Enhanced Default v1.131 Fast</td>
 		<td><a href="//adfoc.us/39232281663413" target="_blank"
 			rel="noopener">v1.13(old)</a></td>
-		<td><a href="" target="_blank"
+		<td><a href="//www.patreon.com/Sildur" target="_blank"
 			rel="noopener">v1.131 (January 1st)</a></td>
-		<td><a href="//www.patreon.com/Sildur"
-		target="_blank" rel="noopener">Patreon Early Access</a></td>
 	</tr>
 	<tr>
 		<td>Sildur's Enhanced Default v1.131 Fancy</td>
 		<td><a href="//adfoc.us/39232281938091" target="_blank"
 			rel="noopener">v1.13(old)</a></td>
-		<td><a href="" target="_blank"
+		<td><a href="//www.patreon.com/Sildur" target="_blank"
 			rel="noopener">v1.131 (January 1st)</a></td>
-		<td><a href="//www.patreon.com/Sildur"
-		target="_blank" rel="noopener">Patreon Early Access</a></td>
 	</tr>		
 	<tr>
 		<td><a href="/changelogs/#enhanced" rel="section">Changelog</a></td>


### PR DESCRIPTION
At the moment, it looks to me as if there are three options for the downloads, one for each column - the old v1.31, the current v1.32 build, with a broken link, and the even newer Patreon Early Access builds. Apparently, the v1.32 build and the Patreon build are the same thing, so I made them into one column with a header to indicate that it's early access, I also removed the broken link and replaced it with the Patreon link.

Before:
![image](https://user-images.githubusercontent.com/13787163/147857608-f0d26772-18a8-4182-8ff1-f3fba14d55d1.png)

After:
![image](https://user-images.githubusercontent.com/13787163/147857615-7cde75b0-c211-4aaa-8a08-21c43196e0c2.png)

Fixes #196 