### PR TITLE
Update link to Iris in Installation page

### DIFF
--- a/install/index.html
+++ b/install/index.html
@@ -275,7 +275,7 @@
                                                         target="_blank" rel="noopener">Minecraft,</a></b> setup your
                                                 game profile of the version you want to run.
                                                 <br> 2. Download and run the <b><a
-                                                        href="https://irisshaders.net/download.html" target="_blank"
+                                                        href="https://www.irisshaders.dev/download" target="_blank"
                                                         rel="noopener">Iris</a></b> jar file with <b><a
                                                         href="https://www.java.com/en/download" target="_blank"
                                                         rel="noopener">Java</a></b>.


### PR DESCRIPTION
The Installation page currently links to irisshaders.net which appears to no longer be owned by the Iris project. The project now exists on https://irisshaders.dev which is the link referenced in the https://github.com/IrisShaders/Iris repository.

Making this PR since a friend ended up downloading adware from the old domain 🫠